### PR TITLE
允许使用多套密钥加密解密

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ type Client interface {
 	//      0   - 成功
 	//  	!=0 - 失败
 	//
-	DecryptData(encryptRandomKey string, encryptMsg string) (msg ChatMessage, err error)
+	DecryptData(encryptRandomKey string, encryptMsg string,specificPrivateKey string) (msg ChatMessage, err error)
 
 	// GetMediaData 拉取媒体消息函数
 	//

--- a/client_linux.go
+++ b/client_linux.go
@@ -102,8 +102,11 @@ func (s *SdkClient) GetChatData(seq uint64, limit uint64, proxy string, passwd s
 *      0   - 成功
 *      !=0 - 失败
  */
-func (s *SdkClient) DecryptData(encryptRandomKey string, encryptMsg string) (msg ChatMessage, err error) {
-	encryptKey, err := RSADecryptBase64(s.privateKey, encryptRandomKey)
+func (s *SdkClient) DecryptData(encryptRandomKey string, encryptMsg string,specificPrivateKey string) (msg ChatMessage, err error) {
+	if(specificPrivateKey == ""){
+		specificPrivateKey = s.privateKey
+	}
+	encryptKey, err := RSADecryptBase64(specificPrivateKey, encryptRandomKey)
 	if err != nil {
 		return msg, err
 	}


### PR DESCRIPTION
允许使用多套密钥加密解密

企业微信的解密公私钥的时效是以设置是发生且有效为存档依据的
1 日 设置一套密钥 ,密钥版本号 为 1
2 日 又设置一套私钥,密钥版本号 为 2
2日上线的代码 拉取 1日的聊天记录解密,还是使用 1日的那套密钥

企业微信会在消息内给出此消息是使用哪套密钥对进行加密的提示 `publickey_ver` 字段

因此,客户端需要有根据这个提示,使用不同的私钥进行解密的能力


Ref: https://www.dongchuanmin.com/linux/3046.html

![image](https://github.com/user-attachments/assets/ed25bc24-7d45-40e5-a12c-800dcf8b34a2)



